### PR TITLE
Fix "'FLT_EPSILON' was not declared in this scope" error in src/SpecFile_spe.cpp"

### DIFF
--- a/src/SpecFile_spe.cpp
+++ b/src/SpecFile_spe.cpp
@@ -35,6 +35,7 @@
 #include <stdexcept>
 #include <algorithm>
 #include <functional>
+#include <cfloat>
 
 
 #include "SpecUtils/SpecFile.h"


### PR DESCRIPTION
The modification is in need to compile on my Linux boxes (Fedora 35, x86_64).