### PR TITLE
error handling

### DIFF
--- a/src/Filesystem.cpp
+++ b/src/Filesystem.cpp
@@ -300,7 +300,12 @@ bool is_directory( const std::string &name )
   return S_ISDIR(statbuf.st_mode);
 #else
   struct stat statbuf;
-  stat( name.c_str(), &statbuf);
+  if( stat( name.c_str(), &statbuf) < 0 ) {
+    if(errno == ENOENT) {
+      return false;
+    }
+    throw runtime_error( "error getting status of directory" );
+  }
   return S_ISDIR(statbuf.st_mode);
 #endif
 }//bool is_directory( const std::string &name )


### PR DESCRIPTION
in practice, stat will often return ENOENT when passed in value is of a directory that does not exist.