### PR TITLE
when copying a spectrum file, copy analyses.

### DIFF
--- a/src/SpecFile.cpp
+++ b/src/SpecFile.cpp
@@ -4090,6 +4090,7 @@ const SpecFile &SpecFile::operator=( const SpecFile &rhs )
   component_versions_     = rhs.component_versions_;
   mean_latitude_          = rhs.mean_latitude_;
   mean_longitude_         = rhs.mean_longitude_;
+  detectors_analysis_     = rhs.detectors_analysis_;
   properties_flags_       = rhs.properties_flags_;
   
   modified_               = rhs.modified_;


### PR DESCRIPTION
Ok, Maybe I just don't get it.  Why aren't we copying this?

This is a draft pull request.  Please let me know your thoughts and if this is close to something we want or why this wasn't copied.

I certainly like to see the analysis information in the output, but maybe this information is supposed to get through using another system.