### PR TITLE
Don't abort parsing when many "invalid" lines are present.

### DIFF
--- a/src/SpecFile_radiacode.cpp
+++ b/src/SpecFile_radiacode.cpp
@@ -514,13 +514,16 @@ bool SpecFile::load_from_radiacode_spectrogram( std::istream& input )
     uint64_t last_timestamp = timestamp;
     size_t skipped_lines = 0, total_lines = 0;
     string line;
+	bool line_warning = true;
     while( safe_get_line(input, line, 64*1024) )
     {
       total_lines += 1;
       
       // We'll be pretty generous about allowing invalid lines
-      if( (skipped_lines > 5) && (total_lines > 10) && (skipped_lines > (total_lines/10)) )
-        throw runtime_error("Too many invalid lines");
+      if( line_warning && (skipped_lines > 5) && (total_lines > 10) && (skipped_lines > (total_lines/10)) ) {
+        warnings.push_back("Many invalid lines detected");
+        line_warning = false;
+      }
 
       trim( line );
       if( line.empty() )


### PR DESCRIPTION
Propagate a warning up, though, in case the user cares.

This interferes with loading valid spectrograms containing an interval where the radiacode device reports no photons detected. This happens when the device is briefly exposed to a fairly intense source, eg. an airport baggage scanner.

Under these conditions, the spectrogram will contain lines looking like this:
```
...
133473254726500000	1
133473254739130000	1
133473254751890000	1
...
```

Depending on the detector model, and the source dose rates, the device has been seen to return no events for between 3 and 15 seconds.