### PR TITLE
radiacode app sometimes mis-identifies the device

### DIFF
--- a/src/SpecFile_radiacode.cpp
+++ b/src/SpecFile_radiacode.cpp
@@ -28,6 +28,7 @@
 #include <sstream>
 #include <iostream>
 #include <stdexcept>
+#include <regex>
 
 #include "rapidxml/rapidxml.hpp"
 
@@ -357,19 +358,30 @@ bool SpecFile::load_from_radiacode(std::istream& input) {
       if( serial_num_node && serial_num_node->value_size() )
       {
         instrument_id_ = xml_value_str( serial_num_node );
-        // Under some circumstances, the radiacode app will mis-identify the source device.
-        // I have several data files produced by RC-102-XXXXXX and RC-103-YYYYYY where the
-        // DeviceConfigReference/Name node is "RadiaCode-101".
-        // Test for this discrepancy and patch the instrument model field if necessary.
-        string model_num = instrument_id_.substr(2,4); // "RC-10X-NNNNNN" -> "-10X"
-        if ( instrument_id_.length() && (model_num.length() == 4) )
+        std::regex rc_sn_regex("^RC-(\\d{3})-\\d{6}$");
+		std::smatch match_result;
+
+		if ( std::regex_search(instrument_id_, match_result, rc_sn_regex) )
         {
-          string model_from_sn = "RadiaCode" + model_num;
+          // Under some circumstances, the radiacode app will mis-identify the source device.
+          // I have several data files produced by RC-102-XXXXXX and RC-103-YYYYYY where the
+          // DeviceConfigReference/Name node is "RadiaCode-101".
+          // Test for this discrepancy and patch the instrument model field if necessary.
+          string model_from_sn = "RadiaCode-" + static_cast<string>(match_result[1]);
           if ( instrument_id_.find( model_from_sn ) == string::npos)
           {
-            parse_warnings_.push_back( "DeviceConfigModel is not consistent with SerialNumber");
+#if(PERFORM_DEVELOPER_CHECKS)
+            parse_warnings_.push_back(
+              "DeviceConfigModel " + instrument_model_ +
+              " is not consistent with SerialNumber " + instrument_id_ +
+              ". Patching to " + model_from_sn );
+#endif
             instrument_model_ = model_from_sn;
           }
+#if(PERFORM_DEVELOPER_CHECKS)
+        } else {
+          parse_warnings_.push_back( "SerialNumber " + instrument_id_ + " does not match expected format" );
+#endif
         }
       }
       


### PR DESCRIPTION
This diff adds a check based on the serial number; if a discrepancy is found the `instrument_model_` field is patched to the assumed model. As best I can tell, the rest of the spectrum output is correct.

Example files for test suite sent separately.