### PR TITLE
More radiacode models

### DIFF
--- a/SpecUtils/SpecFile.h
+++ b/SpecUtils/SpecFile.h
@@ -342,7 +342,7 @@ enum class DetectorType : int
   MicroDetective,
   MicroRaider,
   /** Scan-Electronics RadiaCode-10x detector with CsI(Tl) scintillator */
-  RadiaCode,
+  RadiaCodeCsI10,
 
   /** Raysid 5cm³ CsI/Tl detector */
   Raysid,

--- a/SpecUtils/SpecFile.h
+++ b/SpecUtils/SpecFile.h
@@ -341,8 +341,12 @@ enum class DetectorType : int
   Falcon5000,
   MicroDetective,
   MicroRaider,
-  /** Scan-Electronics RadiaCode-10x detector with CsI(Tl) scintillator */
+  /** Scan-Electronics RadiaCode-10x detector with 10x10x10mm CsI(Tl) scintillator */
   RadiaCodeCsI10,
+  /** Scan-Electronics RadiaCode-110 detector with 14x14x14mm CsI(Tl) scintillator */
+  RadiaCodeCsI14,
+  /** Scan-Electronics RadiaCode-103G detector with 10x10x10mm GAGG scintillator */
+  RadiaCodeGAGG10,
 
   /** Raysid 5cm³ CsI/Tl detector */
   Raysid,
@@ -1771,6 +1775,7 @@ public:
   bool load_phd_file( const std::string &filename );
   bool load_lzs_file( const std::string &filename );
   bool load_radiacode_file( const std::string &filename );
+  bool guess_detector_from_radiacode_model( void );
   bool load_xml_scan_data_file( const std::string &filename );
   bool load_json_file( const std::string &filename );
   bool load_caen_gxml_file(const std::string& filename);

--- a/bindings/c/SpecUtils_c.cpp
+++ b/bindings/c/SpecUtils_c.cpp
@@ -221,8 +221,8 @@ static_assert( static_cast<int>(SpecUtils_DetectorType::SpecUtils_Det_MicroDetec
 static_assert( static_cast<int>(SpecUtils_DetectorType::SpecUtils_Det_MicroRaider) 
               == static_cast<int>(SpecUtils::DetectorType::MicroRaider),
               "SpecUtils_DetectorType needs updating" );
-static_assert( static_cast<int>(SpecUtils_DetectorType::SpecUtils_Det_RadiaCode) 
-              == static_cast<int>(SpecUtils::DetectorType::RadiaCode),
+static_assert( static_cast<int>(SpecUtils_DetectorType::SpecUtils_Det_RadiaCodeCsI10)
+              == static_cast<int>(SpecUtils::DetectorType::RadiaCodeCsI10),
               "SpecUtils_DetectorType needs updating" );
 static_assert( static_cast<int>(SpecUtils_DetectorType::SpecUtils_Det_Interceptor) 
               == static_cast<int>(SpecUtils::DetectorType::Interceptor),

--- a/bindings/c/SpecUtils_c.h
+++ b/bindings/c/SpecUtils_c.h
@@ -459,7 +459,7 @@ enum SpecUtils_DetectorType
   SpecUtils_Det_DetectiveEx, SpecUtils_Det_DetectiveEx100, SpecUtils_Det_DetectiveEx200,
   SpecUtils_Det_DetectiveX, SpecUtils_Det_SAIC8, SpecUtils_Det_Falcon5000,
   SpecUtils_Det_MicroDetective, SpecUtils_Det_MicroRaider,
-  SpecUtils_Det_RadiaCode, SpecUtils_Det_Interceptor, SpecUtils_Det_RadHunterNaI,
+  SpecUtils_Det_RadiaCodeCsI10, SpecUtils_Det_Interceptor, SpecUtils_Det_RadHunterNaI,
   SpecUtils_Det_RadHunterLaBr3, SpecUtils_Det_Rsi701, SpecUtils_Det_Rsi705,
   SpecUtils_Det_AvidRsi, SpecUtils_Det_OrtecRadEagleNai, SpecUtils_Det_OrtecRadEagleCeBr2Inch,
   SpecUtils_Det_OrtecRadEagleCeBr3Inch, SpecUtils_Det_OrtecRadEagleLaBr, SpecUtils_Det_Sam940LaBr3,

--- a/bindings/c/SpecUtils_c.h
+++ b/bindings/c/SpecUtils_c.h
@@ -459,7 +459,7 @@ enum SpecUtils_DetectorType
   SpecUtils_Det_DetectiveEx, SpecUtils_Det_DetectiveEx100, SpecUtils_Det_DetectiveEx200,
   SpecUtils_Det_DetectiveX, SpecUtils_Det_SAIC8, SpecUtils_Det_Falcon5000,
   SpecUtils_Det_MicroDetective, SpecUtils_Det_MicroRaider,
-  SpecUtils_Det_RadiaCodeCsI10, SpecUtils_Det_Interceptor, SpecUtils_Det_RadHunterNaI,
+  SpecUtils_Det_Interceptor, SpecUtils_Det_RadHunterNaI,
   SpecUtils_Det_RadHunterLaBr3, SpecUtils_Det_Rsi701, SpecUtils_Det_Rsi705,
   SpecUtils_Det_AvidRsi, SpecUtils_Det_OrtecRadEagleNai, SpecUtils_Det_OrtecRadEagleCeBr2Inch,
   SpecUtils_Det_OrtecRadEagleCeBr3Inch, SpecUtils_Det_OrtecRadEagleLaBr, SpecUtils_Det_Sam940LaBr3,
@@ -467,6 +467,7 @@ enum SpecUtils_DetectorType
   SpecUtils_Det_RIIDEyeNaI, SpecUtils_Det_RIIDEyeLaBr, SpecUtils_Det_RadSeekerNaI,
   SpecUtils_Det_RadSeekerLaBr, SpecUtils_Det_VerifinderNaI, SpecUtils_Det_VerifinderLaBr,
   SpecUtils_Det_KromekD3S, SpecUtils_Det_Fulcrum, SpecUtils_Det_Fulcrum40h, SpecUtils_Det_Sam950,
+  SpecUtils_Det_RadiaCodeCsI10, SpecUtils_Det_RadiaCodeCsI14, SpecUtils_Det_RadiaCodeGAGG10,
   SpecUtils_Det_Unknown
 };//enum SpecUtils_DetectorType
   

--- a/src/SpecFile.cpp
+++ b/src/SpecFile.cpp
@@ -1400,7 +1400,9 @@ const std::string &detectorTypeToString( const DetectorType type )
   static const string sm_UnknownDetectorStr           = "Unknown";
   static const string sm_MicroDetectiveDetectorStr    = "MicroDetective";
   static const string sm_MicroRaiderDetectorStr       = "MicroRaider";
-  static const string sm_RadiaCodeDetectorStr         = "RadiaCode-10X";
+  static const string sm_RadiaCode10XDetectorStr      = "RadiaCode-10X";
+  static const string sm_RadiaCode110DetectorStr      = "RadiaCode-110";
+  static const string sm_RadiaCode103GDetectorStr     = "RadiaCode-103G";
   static const string sm_InterceptorStr               = "Interceptor";
   static const string sm_Sam940DetectorStr            = "SAM940";
   static const string sm_Sam940Labr3DetectorStr       = "SAM940LaBr3";
@@ -1479,7 +1481,11 @@ const std::string &detectorTypeToString( const DetectorType type )
     case DetectorType::MicroRaider:
       return sm_MicroRaiderDetectorStr;
     case DetectorType::RadiaCodeCsI10:
-      return sm_RadiaCodeDetectorStr;
+      return sm_RadiaCode10XDetectorStr;
+    case DetectorType::RadiaCodeCsI14:
+      return sm_RadiaCode103GDetectorStr;
+    case DetectorType::RadiaCodeGAGG10:
+      return sm_RadiaCode10XDetectorStr;
     case DetectorType::Interceptor:
       return sm_InterceptorStr;
     case DetectorType::Sam940:
@@ -5619,7 +5625,10 @@ void SpecFile::cleanup_after_load( const unsigned int flags )
          && meas->real_time() > 0.00000001
          && !meas->derived_data_properties()  //make sure not derived data
          && ((meas->real_time() < 15.0)   //20181108: some search systems will take one spectra every like ~10 seconds
-             || ((detector_type_ == SpecUtils::DetectorType::RadiaCodeCsI10) // Radiacode detectors can take like 30 second spectra
+             // Radiacode detectors can take spectra over many seconds or minutes
+             || (((detector_type_ == SpecUtils::DetectorType::RadiaCodeCsI10)
+             || (detector_type_ == SpecUtils::DetectorType::RadiaCodeCsI10)
+             || (detector_type_ == SpecUtils::DetectorType::RadiaCodeGAGG10))
                  && (meas->real_time() < 125.0)) ) )
       {
         ++pt_num_items;
@@ -6847,7 +6856,23 @@ void SpecFile::set_detector_type_from_other_info()
       detector_type_ = DetectorType::Fulcrum;
     return;
   }//if( icontains(instrument_model_, "Fulcrum") )
-  
+
+  if( icontains(instrument_model_, "RadiaCode-103G") )
+  {
+    if( manufacturer_.empty() )
+      manufacturer_ = "Scan-Electronics";
+    detector_type_ = SpecUtils::DetectorType::RadiaCodeGAGG10;
+    return;
+  }
+
+  if( icontains(instrument_model_, "RadiaCode-110") )
+  {
+    if( manufacturer_.empty() )
+      manufacturer_ = "Scan-Electronics";
+    detector_type_ = SpecUtils::DetectorType::RadiaCodeCsI14;
+    return;
+  }
+
   if( icontains(instrument_model_, "RadiaCode") )
   {
     if( manufacturer_.empty() )

--- a/src/SpecFile.cpp
+++ b/src/SpecFile.cpp
@@ -1400,7 +1400,7 @@ const std::string &detectorTypeToString( const DetectorType type )
   static const string sm_UnknownDetectorStr           = "Unknown";
   static const string sm_MicroDetectiveDetectorStr    = "MicroDetective";
   static const string sm_MicroRaiderDetectorStr       = "MicroRaider";
-  static const string sm_RadiaCodeDetectorStr         = "RadiaCode-102";
+  static const string sm_RadiaCodeDetectorStr         = "RadiaCode-10X";
   static const string sm_InterceptorStr               = "Interceptor";
   static const string sm_Sam940DetectorStr            = "SAM940";
   static const string sm_Sam940Labr3DetectorStr       = "SAM940LaBr3";
@@ -1432,7 +1432,7 @@ const std::string &detectorTypeToString( const DetectorType type )
   
 //  GN3, InSpector 1000 LaBr3, Pager-S, SAM-Eagle-LaBr, GR130, SAM-Eagle-NaI-3x3
 //  InSpector 1000 NaI, RadPack, SpiR-ID LaBr3, Interceptor, Radseeker, SpiR-ID NaI
-//  GR135Plus, LRM, Raider, HRM, LaBr3PNNL, Transpec, Falcon 5000, Ranger, RadiaCode-102
+//  GR135Plus, LRM, Raider, HRM, LaBr3PNNL, Transpec, Falcon 5000, Ranger, RadiaCode-10X
 //  MicroDetective, FieldSpec, IdentiFINDER-NG, SAM-935, NaI 3x3, SAM-Eagle-LaBr3
 
   switch( type )
@@ -1478,7 +1478,7 @@ const std::string &detectorTypeToString( const DetectorType type )
       return sm_MicroDetectiveDetectorStr;
     case DetectorType::MicroRaider:
       return sm_MicroRaiderDetectorStr;
-    case DetectorType::RadiaCode:
+    case DetectorType::RadiaCodeCsI10:
       return sm_RadiaCodeDetectorStr;
     case DetectorType::Interceptor:
       return sm_InterceptorStr;
@@ -5619,7 +5619,7 @@ void SpecFile::cleanup_after_load( const unsigned int flags )
          && meas->real_time() > 0.00000001
          && !meas->derived_data_properties()  //make sure not derived data
          && ((meas->real_time() < 15.0)   //20181108: some search systems will take one spectra every like ~10 seconds
-             || ((detector_type_ == SpecUtils::DetectorType::RadiaCode) // Radiacode detectors can take like 30 second spectra
+             || ((detector_type_ == SpecUtils::DetectorType::RadiaCodeCsI10) // Radiacode detectors can take like 30 second spectra
                  && (meas->real_time() < 125.0)) ) )
       {
         ++pt_num_items;
@@ -6852,7 +6852,7 @@ void SpecFile::set_detector_type_from_other_info()
   {
     if( manufacturer_.empty() )
       manufacturer_ = "Scan-Electronics";
-    detector_type_ = SpecUtils::DetectorType::RadiaCode;
+    detector_type_ = SpecUtils::DetectorType::RadiaCodeCsI10;
     return;
   }
   

--- a/src/SpecFile_n42.cpp
+++ b/src/SpecFile_n42.cpp
@@ -580,7 +580,7 @@ std::string determine_gamma_detector_kind_code( const SpecUtils::SpecFile &sf )
       break;
       
     case SpecUtils::DetectorType::KromekD3S:
-    case SpecUtils::DetectorType::RadiaCode:
+    case SpecUtils::DetectorType::RadiaCodeCsI10:
     case SpecUtils::DetectorType::Raysid:
       det_kind = "CsI";
       break;

--- a/src/SpecFile_n42.cpp
+++ b/src/SpecFile_n42.cpp
@@ -581,8 +581,14 @@ std::string determine_gamma_detector_kind_code( const SpecUtils::SpecFile &sf )
       
     case SpecUtils::DetectorType::KromekD3S:
     case SpecUtils::DetectorType::RadiaCodeCsI10:
+    case SpecUtils::DetectorType::RadiaCodeCsI14:
     case SpecUtils::DetectorType::Raysid:
       det_kind = "CsI";
+      break;
+
+    // GAGG (gadolinium aluminum gallium garnet) is not defined in my copy of N42, but neither is CLLBC
+    case SpecUtils::DetectorType::RadiaCodeGAGG10:
+      det_kind = "GAGG";
       break;
 
     case SpecUtils::DetectorType::KromekD5:

--- a/src/SpecFile_radiacode.cpp
+++ b/src/SpecFile_radiacode.cpp
@@ -443,7 +443,7 @@ bool SpecFile::load_from_radiacode(std::istream& input) {
     {
       instrument_type_ = "Spectroscopic Personal Radiation Detector";
       manufacturer_ = "Scan-Electronics";
-      detector_type_ = SpecUtils::DetectorType::RadiaCode;
+      detector_type_ = SpecUtils::DetectorType::RadiaCodeCsI10;
     }else
     {
       // File probably made with BecqMoni
@@ -726,7 +726,7 @@ bool SpecFile::load_from_radiacode_spectrogram( std::istream& input )
     
     instrument_type_ = "Spectroscopic Personal Radiation Detector";
     manufacturer_ = "Scan-Electronics";
-    detector_type_ = SpecUtils::DetectorType::RadiaCode;
+    detector_type_ = SpecUtils::DetectorType::RadiaCodeCsI10;
     
     cleanup_after_load();
   }catch( std::exception & )

--- a/src/SpecFile_radiacode.cpp
+++ b/src/SpecFile_radiacode.cpp
@@ -67,6 +67,28 @@ namespace
 
 namespace SpecUtils {
 
+// there are at least two places where this logic is done, make it a function
+bool SpecFile::guess_detector_from_radiacode_model(void){
+    if( icontains( instrument_model_, "RadiaCode-103G" ) ) {
+      instrument_type_ = "Spectroscopic Personal Radiation Detector";
+      manufacturer_ = "Scan-Electronics";
+      detector_type_ = SpecUtils::DetectorType::RadiaCodeGAGG10;
+      return true;
+    } else if( icontains( instrument_model_, "RadiaCode-110" ) ) {
+      instrument_type_ = "Spectroscopic Personal Radiation Detector";
+      manufacturer_ = "Scan-Electronics";
+      detector_type_ = SpecUtils::DetectorType::RadiaCodeCsI14;
+      return true;
+    } else if( icontains( instrument_model_, "RadiaCode-" ) ) {
+      instrument_type_ = "Spectroscopic Personal Radiation Detector";
+      manufacturer_ = "Scan-Electronics";
+      detector_type_ = SpecUtils::DetectorType::RadiaCodeCsI10;
+      return true;
+    } else {
+      return false;
+    }
+} // bool SpecFile::guess_detector_from_radiacode_model(void)
+
 bool SpecFile::load_radiacode_file(const std::string& filename) {
 #ifdef _WIN32
   ifstream input(convert_from_utf8_to_utf16(filename).c_str(),
@@ -438,17 +460,9 @@ bool SpecFile::load_from_radiacode(std::istream& input) {
         }
       }//if( background_node )
     }//XML_FOREACH_CHILD( n_root, data_list_node, "ResultData" )
-    
-    if( icontains( instrument_model_, "RadiaCode-" ) )
-    {
-      instrument_type_ = "Spectroscopic Personal Radiation Detector";
-      manufacturer_ = "Scan-Electronics";
-      detector_type_ = SpecUtils::DetectorType::RadiaCodeCsI10;
-    }else
-    {
-      // File probably made with BecqMoni
-    }
-    
+
+    guess_detector_from_radiacode_model();
+
     cleanup_after_load();
   }catch( std::exception & )
   {
@@ -558,7 +572,7 @@ bool SpecFile::load_from_radiacode_spectrogram( std::istream& input )
     uint64_t last_timestamp = timestamp;
     size_t skipped_lines = 0, total_lines = 0;
     string line;
-	bool line_warning = true;
+	  bool line_warning = true;
     while( safe_get_line(input, line, 64*1024) )
     {
       total_lines += 1;
@@ -724,9 +738,7 @@ bool SpecFile::load_from_radiacode_spectrogram( std::istream& input )
     if( !comment.empty() )
       remarks_.push_back( "Comment: " + comment );
     
-    instrument_type_ = "Spectroscopic Personal Radiation Detector";
-    manufacturer_ = "Scan-Electronics";
-    detector_type_ = SpecUtils::DetectorType::RadiaCodeCsI10;
+    guess_detector_from_radiacode_model();
     
     cleanup_after_load();
   }catch( std::exception & )

--- a/src/SpecFile_spc.cpp
+++ b/src/SpecFile_spc.cpp
@@ -1389,6 +1389,8 @@ bool SpecFile::write_binary_spc( std::ostream &output,
     case DetectorType::KromekGR1:
     case DetectorType::KromekD5:
     case DetectorType::RadiaCodeCsI10:
+    case DetectorType::RadiaCodeCsI14:
+    case DetectorType::RadiaCodeGAGG10:
     case DetectorType::Fulcrum:
     case DetectorType::Fulcrum40h:
     case DetectorType::Sam950:

--- a/src/SpecFile_spc.cpp
+++ b/src/SpecFile_spc.cpp
@@ -1388,7 +1388,7 @@ bool SpecFile::write_binary_spc( std::ostream &output,
     case DetectorType::Raysid:
     case DetectorType::KromekGR1:
     case DetectorType::KromekD5:
-    case DetectorType::RadiaCode:
+    case DetectorType::RadiaCodeCsI10:
     case DetectorType::Fulcrum:
     case DetectorType::Fulcrum40h:
     case DetectorType::Sam950:


### PR DESCRIPTION
There are now 5 radiacode models known to exist - RC101, RC102, RC103, RC103G, and RC110 - and they don't all use the same detector. This diff adds knowledge of the three different scintillators used.

As there don't seem to be any mining facilities near me I can't hope for a couple of Cs137 sources to fall off a truck, so my attempts at computing dead time will be rather crude.

[Radiacode_th232.zip](https://github.com/user-attachments/files/21781960/Radiacode_th232.zip)
